### PR TITLE
Fix object height calculation

### DIFF
--- a/src/grasplan/tools/support_plane_tools.py
+++ b/src/grasplan/tools/support_plane_tools.py
@@ -325,7 +325,7 @@ def attached_obj_height(attached_obj: str, planning_scene: PlanningScene, offset
         The height of the attached object.
     """
     collision_object = get_obj_from_planning_scene(attached_obj, planning_scene)
-    half_height_att_obj = list(planning_scene.get_attached_objects().values())[0].object.primitives[0].dimensions[2]  
+    half_height_att_obj = list(planning_scene.get_attached_objects().values())[0].object.primitives[0].dimensions[2] / 2
     return half_height_att_obj + collision_object.pose.position.z * 2 + offset
 
 # Example usage


### PR DESCRIPTION
This bug caused the objects to always be placed object_height/2 too high over the table.