### PR TITLE
Fix table plane adjustment parameters

### DIFF
--- a/src/grasplan/place.py
+++ b/src/grasplan/place.py
@@ -202,7 +202,7 @@ class PlaceTools():
         plane = obj_to_plane(support_object, self.scene)
 
         # scale down plane to account for obj width and length
-        plane = adjust_plane(plane, 0.05)
+        plane = adjust_plane(plane, -0.15, -0.15)
 
         # publish plane as marker for visualization purposes
         self.plane_vis_pub.publish(make_plane_marker_msg(self.global_reference_frame, plane))


### PR DESCRIPTION
Before, the allowed placement area was the size of the table plane, *extended* by 0.05 in the x direction (and no adjustment in the y direction).

After this commit, it's the table plane, reduced by 0.15 m in x and y direction (because the long side of the KLT box is around 0.30 m, so with this adjustment it always fits fully onto the table).