### PR TITLE
Fix update_mesh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,6 @@ repos:
       - id: check-vcs-permalinks
       - id: check-xml
       - id: check-yaml
-        exclude: mobipick_description/config/joint_limits.yaml
       - id: debug-statements
       - id: end-of-file-fixer
         exclude: &excludes |

--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>mobipick_pick_n_place</exec_depend>
   <exec_depend>moveit_commander</exec_depend>
   <exec_depend>moveit_msgs</exec_depend>
+  <exec_depend>pbr_objects</exec_depend>
   <exec_depend>rostopic</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -37,6 +37,7 @@
   <exec_depend>moveit_commander</exec_depend>
   <exec_depend>moveit_msgs</exec_depend>
   <exec_depend>pbr_objects</exec_depend>
+  <exec_depend>resource_retriever</exec_depend>
   <exec_depend>rostopic</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>

--- a/src/grasplan/rqt_grasplan/rqt_grasplan.py
+++ b/src/grasplan/rqt_grasplan/rqt_grasplan.py
@@ -85,7 +85,7 @@ class RqtGrasplan(Plugin):
         self.test_pose_pub = rospy.Publisher('/test_pose', PoseStamped, queue_size=1)
 
         # parameters
-        obj_pkg_name = rospy.get_param('~obj_pkg_name', 'mobipick_gazebo')
+        obj_pkg_name = rospy.get_param('~obj_pkg_name', 'pbr_objects')
         if rospy.has_param('~object_name'):
             self.object_class = rospy.get_param('~object_name')
             # set object name to textbox

--- a/src/grasplan/visualization/grasp_visualizer.py
+++ b/src/grasplan/visualization/grasp_visualizer.py
@@ -18,7 +18,7 @@ class GraspVisualizer:
     def __init__(self):
         # parameters
         self.object_name = rospy.get_param('~object_name', 'multimeter')
-        self.object_pkg = rospy.get_param('~object_pkg', 'mobipick_gazebo')
+        self.object_pkg = rospy.get_param('~object_pkg', 'pbr_objects')
         self.global_reference_frame = rospy.get_param('~global_reference_frame', 'object')
         transform_linear_x = rospy.get_param('~transform_linear_x', 0.0)
         transform_linear_y = rospy.get_param('~transform_linear_y', 0.0)
@@ -77,7 +77,7 @@ class GraspVisualizer:
         )
         self.pose_array_pub.publish(pose_array_msg)
 
-    def update_mesh(self, object_name='multimeter', object_pkg='mobipick_gazebo'):
+    def update_mesh(self, object_name='multimeter', object_pkg='pbr_objects'):
         mesh_accepted_formats = ['.dae', '.obj']
         mesh_path = None
         for mesh_accepted_format in mesh_accepted_formats:

--- a/src/grasplan/visualization/grasp_visualizer.py
+++ b/src/grasplan/visualization/grasp_visualizer.py
@@ -9,6 +9,7 @@ import tf
 import rospy
 import std_msgs
 import geometry_msgs
+import resource_retriever
 from geometry_msgs.msg import PoseStamped, PoseArray
 from visualization_msgs.msg import Marker
 from grasplan.grasp_planner.handcoded_grasp_planner import HandcodedGraspPlanner
@@ -80,11 +81,14 @@ class GraspVisualizer:
     def update_mesh(self, object_name='multimeter', object_pkg='pbr_objects'):
         mesh_accepted_formats = ['.dae', '.obj']
         mesh_path = None
+        file_was_found = False
         for mesh_accepted_format in mesh_accepted_formats:
             mesh_path = f'package://{object_pkg}/meshes/{object_name}/{object_name}{mesh_accepted_format}'
-            if os.path.exists(mesh_path):
-                continue
-        if mesh_path is None:
+            mesh_file = resource_retriever.get_filename(mesh_path, use_protocol=False)
+            if os.path.exists(mesh_file):
+                file_was_found = True
+                break
+        if not file_was_found:
             rospy.logerr('failed to update mesh')
             return
         angular_q = tf.transformations.quaternion_from_euler(


### PR DESCRIPTION
There were several problems with the `update_mesh` function:

1. It treated the resource URI (`package://...`) as a file, so the `os.path.exists` always failed.
2. The loop nevertheless always `continue`d instead of `break`ing.
3. The error check never checked whether the "file exists" check succeeded.

As a result, the function always used the `.obj` path, no matter if the files existed or not. This PR fixes that.

----------------------------------------------------------------------

I'm also sneaking in two other small fixes in separate commits:

1. Fixing a copy-paste error I made in the pre-commit config.
2. Updating the ROS package that holds the meshes (mobipick_gazebo -> pbr_objects).