### PR TITLE
Resolve circular dependency and build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   rqt_gui
   rqt_gui_py
   std_msgs
+  roslaunch
 )
 
 catkin_python_setup()

--- a/config/examples/planning_scene.yaml
+++ b/config/examples/planning_scene.yaml
@@ -1,109 +1,108 @@
+# a list of boxes to add to the planning scene
+#
+#   +---------+
+#   |         |
+#   | table_4 |
+#   |         |
+#   +---------+
+#                 +-------+
+#                 |       |
+#                 |       |
+#                 |       |
+#                 |table_3|
+#                 |       |
+#                 |       |
+#                 |       |
+#                 +-------+
+#
+#                 +-------+
+#                 |       |
+#                 |       |
+#                 |       |
+#                 |table_2|
+#                 |       |
+#                 |       |
+#                 |       |
+#                 +-------+
+#   +---------+
+#   |         |
+#   | table_1 |
+#   |         |                   x
+#   +---------+                   ^
+#                                 |
+#                                 |
+#                          y <----+ map
+
 planning_scene_boxes:
-- scene_name: 'table'
-  frame_id: 'world'
-  box_x_dimension: 0.8
-  box_y_dimension: 1.4
-  box_z_dimension: 1.02
-  box_position_x: 0.0
-  box_position_y: 1.2
-  box_position_z: 0.51
-  box_orientation_x: 0.0
-  box_orientation_y: 0.0
-  box_orientation_z: 0.0
-  box_orientation_w: 1.0
-- scene_name: 'conveyor_belt_a'
-  frame_id: 'world'
-  box_x_dimension: 0.7
-  box_y_dimension: 3.3
-  box_z_dimension: 0.9
-  box_position_x: 0.8
-  box_position_y: 1.61
-  box_position_z: 0.5
-  box_orientation_x: 0.0
-  box_orientation_y: 0.0
-  box_orientation_z: 0.0
-  box_orientation_w: 1.0
-- scene_name: 'conveyor_belt_b'
-  frame_id: 'world'
-  box_x_dimension: 0.7
-  box_y_dimension: 3.3
-  box_z_dimension: 0.9
-  box_position_x: -0.8
-  box_position_y: 1.61
-  box_position_z: 0.5
-  box_orientation_x: 0.0
-  box_orientation_y: 0.0
-  box_orientation_z: 0.0
-  box_orientation_w: 1.0
-- scene_name: 'insole_rejection_box'
-  frame_id: 'world'
-  box_x_dimension: 0.87
-  box_y_dimension: 0.59
-  box_z_dimension: 0.68
-  box_position_x: 0.8
-  box_position_y: -0.3
-  box_position_z: 0.34
-  box_orientation_x: 0.0
-  box_orientation_y: 0.0
-  box_orientation_z: 0.0
-  box_orientation_w: 1.0
-- scene_name: 'bag_dispenser'
-  frame_id: 'world'
-  box_x_dimension: 0.4
-  box_y_dimension: 0.4
-  box_z_dimension: 0.4
-  box_position_x: 0.0
-  box_position_y: 0.95
-  box_position_z: 1.2
-  box_orientation_x: 0.0
-  box_orientation_y: 0.0
-  box_orientation_z: 0.0
-  box_orientation_w: 1.0
-- scene_name: 'camera'
-  frame_id: 'world'
-  box_x_dimension: 0.1
-  box_y_dimension: 0.05
-  box_z_dimension: 1.95
-  box_position_x: 0.85
-  box_position_y: -1.03
-  box_position_z: 0.975
-  box_orientation_x: 0.0
-  box_orientation_y: 0.0
-  box_orientation_z: 0.0
-  box_orientation_w: 1.0
-- scene_name: 'insole'
-  frame_id: 'world'
-  box_x_dimension: 0.08
-  box_y_dimension: 0.21
-  box_z_dimension: 0.03
-  box_position_x: 0.651695975548497
-  box_position_y: 0.026824067584461393
-  box_position_z: 0.959251808312075
-  box_orientation_x: 6.110598590711796e-06
-  box_orientation_y: 7.2356321459107026e-06
-  box_orientation_z: 0.0456958558567879
-  box_orientation_w: 0.9989553987380126
-- scene_name: 'insole_1'
-  frame_id: 'insole'
-  box_x_dimension: 0.08
-  box_y_dimension: 0.105
-  box_z_dimension: 0.03
-  box_position_x: 0.0
-  box_position_y: -0.525
-  box_position_z: 0.0
-  box_orientation_x: 0.0
-  box_orientation_y: 0.0
-  box_orientation_z: 0.0
-  box_orientation_w: 1.0
-- scene_name: 'insole_2'
-  frame_id: 'insole'
-  box_x_dimension: 0.08
-  box_y_dimension: 0.105
-  box_z_dimension: 0.03
-  box_position_x: 0.0
-  box_position_y: 0.525
-  box_position_z: 0.0
-  box_orientation_x: 0.0
-  box_orientation_y: 0.0
-  box_orientation_z: 0.0
-  box_orientation_w: 1.0
+  - scene_name: 'table_1'
+    frame_id: 'map'
+    box_x_dimension: 0.8
+    box_y_dimension: 0.8
+    box_z_dimension: 0.72
+    box_position_x: 18.3
+    box_position_y: 15.18
+    box_position_z: 0.36
+    box_orientation_x: 0.0
+    box_orientation_y: 0.0
+    box_orientation_z: 0.0
+    box_orientation_w: 1.0
+  - scene_name: 'table_2'
+    frame_id: 'map'
+    box_x_dimension: 1.6
+    box_y_dimension: 0.8
+    box_z_dimension: 0.715
+    box_position_x: 19.565
+    box_position_y: 13.76
+    box_position_z: 0.3575
+    box_orientation_x: 0.0
+    box_orientation_y: 0.0
+    box_orientation_z: 0.0
+    box_orientation_w: 1.0
+  - scene_name: 'table_3'
+    frame_id: 'map'
+    box_x_dimension: 1.6
+    box_y_dimension: 0.8
+    box_z_dimension: 0.715
+    box_position_x: 21.265
+    box_position_y: 13.84
+    box_position_z: 0.3575
+    box_orientation_x: 0.0
+    box_orientation_y: 0.0
+    box_orientation_z: 0.0
+    box_orientation_w: 1.0
+  - scene_name: 'table_4'
+    frame_id: 'map'
+    box_x_dimension: 0.8
+    box_y_dimension: 0.8
+    box_z_dimension: 0.72
+    box_position_x: 22.7
+    box_position_y: 15.04
+    box_position_z: 0.36
+    box_orientation_x: 0.0
+    box_orientation_y: 0.0
+    box_orientation_z: 0.0
+    box_orientation_w: 1.0
+  - scene_name: 'back_wall'
+    frame_id: 'map'
+    box_x_dimension: 5.3
+    box_y_dimension: 0.48
+    box_z_dimension: 2.34
+    box_position_x: 20.45
+    box_position_y: 16.16
+    box_position_z: 1.17
+    box_orientation_x: 0.0
+    box_orientation_y: 0.0
+    box_orientation_z: 0.0
+    box_orientation_w: 1.0
+  - scene_name: 'roof'
+    frame_id: 'map'
+    box_x_dimension: 5.4
+    box_y_dimension: 2.9
+    box_z_dimension: 0.1
+    box_position_x: 20.5
+    box_position_y: 14.96
+    box_position_z: 2.335
+    box_orientation_x: 0.0
+    box_orientation_y: 0.0
+    box_orientation_z: 0.0
+    box_orientation_w: 1.0

--- a/launch/planning_scene/find_planning_scene_boxes_helper.launch
+++ b/launch/planning_scene/find_planning_scene_boxes_helper.launch
@@ -3,9 +3,8 @@
 
   <!-- rosbag full path -->
   <arg name="bag_path" default="" />
-  <arg name="world_config" default="moelk_tables" doc="objects arrangement, options: moelk_tables, cic_tables, truck_assembly" />
-  <arg name="yaml_path_to_read" default="$(find tables_demo_bringup)/config/$(arg world_config)_planning_scene.yaml" />
-  <arg name="yaml_path_to_write" default="$(find tables_demo_bringup)/config/$(arg world_config)_planning_scene.yaml" />
+  <arg name="yaml_path_to_read" default="$(find grasplan)/config/examples/planning_scene.yaml" />
+  <arg name="yaml_path_to_write" default="$(arg yaml_path_to_read)"/>
 
   <!-- upload mobipick urdf model to param server -->
   <include file="$(find mobipick_description)/launch/mobipick/upload_mobipick_description.launch">

--- a/launch/planning_scene/planning_scene_visualization.launch
+++ b/launch/planning_scene/planning_scene_visualization.launch
@@ -1,17 +1,14 @@
 <?xml version="1.0"?>
 <launch>
 
-  <arg name="world_config" default="ai_day" doc="objects arrangement, options: moelk_tables, cic_tables, truck_assembly, ai_day" />
-  <arg name="yaml_path_to_read" default="$(find tables_demo_bringup)/config/$(arg world_config)_planning_scene.yaml" />
+  <arg name="yaml_path_to_read" default="$(find grasplan)/config/examples/planning_scene.yaml" />
   <arg name="yaml_path_to_write" default="$(arg yaml_path_to_read)" />
   <arg name="ignore_set" default="[]" /> <!-- custom list of boxes not to draw in rviz -->
   <arg name="target_frame_dic" default="{'table_2':'table_3'}" /> <!-- express table_2 in table_3 reference frame -->
 
   <!-- rviz visualization of planning scene as markers, by default it publishes to tf -->
   <node pkg="grasplan" type="visualize_planning_scene_node" name="visualize_planning_scene_node" output="screen">
-    <!-- planning scene transforms -->
     <param name="yaml_path_to_read" type="string" value="$(arg yaml_path_to_read)" />
-    <!-- yaml file path to save boxes if requested-->
     <param name="yaml_path_to_write" type="string" value="$(arg yaml_path_to_write)" />
     <!-- a list of planning scene boxes to ignore (not draw) -->
     <rosparam param="ignore_set" subst_value="True">$(arg ignore_set)</rosparam>

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_py</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>roslaunch</build_depend>
 
   <exec_depend>actionlib</exec_depend>
   <exec_depend>actionlib_msgs</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -46,7 +46,6 @@
   <exec_depend>spacenav_node</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
-  <exec_depend>tables_demo_bringup</exec_depend>
   <exec_depend>tf</exec_depend>
   <exec_depend>trajectory_msgs</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/scripts/visualize_planning_scene_node
+++ b/scripts/visualize_planning_scene_node
@@ -5,9 +5,7 @@ Visualizes planning scene with visualize_planning_scene.py. (not tied to moveit)
 Allows hiding elements in the scene, a feature MoveIt lacks.
 '''
 
-import os
 import rospy
-import rospkg
 
 from std_msgs.msg import String
 from grasplan.rqt_planning_scene.visualize_planning_scene import PlanningSceneViz, PlanningSceneVizSettings
@@ -15,12 +13,9 @@ from grasplan.rqt_planning_scene.visualize_planning_scene import PlanningSceneVi
 
 class visualizePlanningSceneNode:
     def __init__(self):
-        package_path = rospkg.RosPack().get_path('grasplan')
-        default_yaml_path = package_path + '/config/examples/planning_scene.yaml'
-        yaml_path_to_read = rospy.get_param('~yaml_path_to_read', default_yaml_path)
-        yaml_path_to_write = rospy.get_param('~yaml_path_to_write', default_yaml_path)
-        if not os.path.exists(yaml_path_to_read):
-            rospy.signal_shutdown(f'yaml path does not exist: {yaml_path_to_read}, shutting down node')
+        yaml_path_to_read = rospy.get_param('~yaml_path_to_read')
+        yaml_path_to_write = rospy.get_param('~yaml_path_to_write')
+
         initial_settings = PlanningSceneVizSettings()
         # a list of planning scene boxes to ignore (not draw)
         initial_settings.ignore_set = set(rospy.get_param('~ignore_set', []))

--- a/src/grasplan/rqt_planning_scene/visualize_planning_scene.py
+++ b/src/grasplan/rqt_planning_scene/visualize_planning_scene.py
@@ -30,6 +30,7 @@ import tf
 
 import os
 import sys
+import pathlib
 import yaml
 import copy
 
@@ -181,15 +182,15 @@ class PlanningSceneViz:
         if not found:
             rospy.logerr(f'cannot modify box, scene_name : {scene_name} not found')
 
-    def load_boxes_from_yaml(self, yaml_path):
-        if yaml_path == '':
-            rospy.logwarn('empty yaml path')
-            return
-        if not os.path.exists(yaml_path):
-            rospy.logerr(f'yaml path does not exist: {yaml_path}')
-            return
+    def load_boxes_from_yaml(self, yaml_path: str) -> None:
+
+        yaml_path = pathlib.Path(yaml_path)
+        if not yaml_path.exists() or not yaml_path.is_file():
+            raise FileNotFoundError(f'yaml file does not exist: {yaml_path}')
+
         with open(yaml_path, 'r') as file:
             yaml_content = file.read()
+
         self.box_list_dictionary = yaml.safe_load(yaml_content)['planning_scene_boxes']
         self.box_list_dictionary_bkp = copy.deepcopy(self.box_list_dictionary)
         # construct a list of all boxes
@@ -201,13 +202,15 @@ class PlanningSceneViz:
     def get_all_boxes_names(self):
         return self.all_boxes_names
 
-    def write_boxes_to_yaml(self, yaml_path_to_write, from_settings=False):
-        if from_settings:
-            yaml_path_to_write = self.settings.yaml_path_to_write
-        with open(yaml_path_to_write, 'w') as yaml_file:
+    def write_boxes_to_yaml(self, yaml_path: str) -> None:
+        yaml_path = pathlib.Path(yaml_path)
+        if not yaml_path.exists() or not yaml_path.is_file():
+            raise FileNotFoundError(f'yaml file does not exist: {yaml_path}')
+
+        with open(yaml_path, 'w') as yaml_file:
             master_dictionary = {'planning_scene_boxes': self.box_list_dictionary}
             yaml.dump(master_dictionary, yaml_file, default_flow_style=False)
-            rospy.loginfo(f'writing boxes to yaml file: {yaml_path_to_write}')
+            rospy.loginfo(f'writing boxes to yaml file: {yaml_path}')
 
     def transform_to_frame(self, object_frame, target_frame):
         # get object transform


### PR DESCRIPTION
Closes #22 

The exec_depend on `tables_demo_bringup` is resolved by eliminating the automatic loading of the appropriate yaml file according to the world config. Instead the path to the yaml files has to be provided manually through an arg or the UI.