### PR TITLE
Cancel actions

### DIFF
--- a/scripts/insert_obj_test_action_client
+++ b/scripts/insert_obj_test_action_client
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 import rospy
@@ -8,43 +8,53 @@ from grasplan.msg import InsertObjectAction, InsertObjectGoal
 
 if __name__ == '__main__':
     rospy.init_node('insert_object_action_client')
+
+    # Check for namespace and arguments
     if len(sys.argv) > 1:
         if sys.argv[1] != '__ns:=mobipick':
-            rospy.logwarn('have you run this node without the mobipick as namespace? if so, it might not work!')
+            rospy.logwarn('Have you run this node without the "mobipick" namespace? It might not work!')
 
         myargv = rospy.myargv()
         if len(myargv) != 3:
-            rospy.logfatal(f'Usage: {myargv[0]} support_surface_name observe_before_placing')
+            rospy.logfatal(f'Usage: {myargv[0]} support_surface_name observe_before_inserting')
             sys.exit(1)
+
+        # Parse arguments
         support_surface_name = myargv[1]
-        if myargv[2] == 'true' or myargv[2] == 'True':
-            observe_before_insert = True
-        elif myargv[2] == 'false' or myargv[2] == 'False':
-            observe_before_insert = False
+        observe_before_insert = myargv[2].lower() == 'true'
     else:
-        rospy.logwarn(
-            'you have run this node without arguments, at least the mobipick namespace is expected! ( __ns:=mobipick )'
-        )
-    timeout = 50.0  # in seconds, default: 50.0
+        rospy.logwarn('Node launched without arguments; expected at least the "mobipick" namespace ( __ns:=mobipick ).')
+        sys.exit(1)
+
+    # Action client setup
+    timeout = 50.0  # Timeout in seconds for waiting for result
     insert_object_server_name = 'insert_object'
     action_client = actionlib.SimpleActionClient(insert_object_server_name, InsertObjectAction)
-    rospy.loginfo(f'waiting for {insert_object_server_name} action server')
+
+    # Wait for the action server to be available
+    rospy.loginfo(f'Waiting for {insert_object_server_name} action server...')
     if action_client.wait_for_server(timeout=rospy.Duration.from_sec(10.0)):
-        rospy.loginfo(f'found {insert_object_server_name} action server')
+        rospy.loginfo(f'Connected to {insert_object_server_name} action server')
+
+        # Send goal to action server
         goal = InsertObjectGoal()
         goal.support_surface_name = support_surface_name
         goal.observe_before_insert = observe_before_insert
-        rospy.loginfo(f'sending insert goal to {insert_object_server_name} action server')
+        rospy.loginfo(f'Sending insert goal to {insert_object_server_name} action server')
         action_client.send_goal(goal)
-        rospy.loginfo(f'waiting for result from {insert_object_server_name} action server')
+
+        # Wait for result with specified timeout
+        rospy.loginfo(f'Waiting for result from {insert_object_server_name} action server...')
         if action_client.wait_for_result(rospy.Duration.from_sec(timeout)):
             result = action_client.get_result()
-            rospy.loginfo(f'{insert_object_server_name} is done with execution, resuĺt was = "{result}"')
+            rospy.loginfo(f'{insert_object_server_name} completed execution with result = "{result}"')
             if result.success:
-                rospy.loginfo('Succesfully inserted object')
+                rospy.loginfo('Successfully inserted object')
             else:
                 rospy.logerr('Failed to insert object')
         else:
-            rospy.logerr('Failed to insert object, timeout?')
+            # Cancel the goal if timeout occurs
+            action_client.cancel_goal()
+            rospy.logerr('Failed to insert object within the allocated time. Goal cancellation was sent.')
     else:
-        rospy.logerr('action server {insert_object_server_name} not available')
+        rospy.logerr(f'Action server {insert_object_server_name} not available within the timeout')

--- a/scripts/pick_obj_test_action_client
+++ b/scripts/pick_obj_test_action_client
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 import rospy
@@ -8,54 +8,66 @@ from grasplan.msg import PickObjectAction, PickObjectGoal
 
 if __name__ == '__main__':
     rospy.init_node('pick_object_action_client')
+
+    # Check for namespace and arguments
     if len(sys.argv) > 1:
         if sys.argv[1] != '__ns:=mobipick':
-            rospy.logwarn('have you run this node without the mobipick as namespace? if so, it might not work!')
+            rospy.logwarn('Have you run this node without the "mobipick" namespace? It might not work!')
 
         myargv = rospy.myargv()
         if len(myargv) < 3:
             rospy.logfatal(f'Usage: {myargv[0]} object_to_pick support_surface_name')
             sys.exit(1)
+
+        # Parse arguments
         object_to_pick = myargv[1]
         support_surface_name = myargv[2]
     else:
         rospy.logwarn(
-            'you have run this node without arguments, at least the mobipick namespace is expected!'
-            ' ( __ns:=mobipick ) ... exiting'
+            'Node launched without arguments; expected at least the "mobipick" namespace ( __ns:=mobipick ). Exiting.'
         )
         sys.exit(1)
-    timeout = 50.0  # in seconds, default: 50.0
+
+    # Action client setup
+    timeout = 50.0  # Timeout in seconds for waiting for result
     pick_object_server_name = 'pick_object'
     action_client = actionlib.SimpleActionClient(pick_object_server_name, PickObjectAction)
-    rospy.loginfo(f'waiting for {pick_object_server_name} action server')
+
+    # Wait for the action server to be available
+    rospy.loginfo(f'Waiting for {pick_object_server_name} action server...')
     if action_client.wait_for_server(timeout=rospy.Duration.from_sec(30.0)):
-        rospy.loginfo(f'found {pick_object_server_name} action server')
+        rospy.loginfo(f'Connected to {pick_object_server_name} action server')
+
+        # Send goal to action server
         goal = PickObjectGoal()
-        goal.object_name = object_to_pick  # pick "any" multimeter
+        goal.object_name = object_to_pick  # does not necessarily needs to be an achored obj
         goal.support_surface_name = support_surface_name
-        # goal.object_name = 'multimeter_1' # pick a specific multimeter
+
+        # Optional ignore list handling
         goal.ignore_object_list = []
         if len(myargv) > 3:
-            for i in range(len(myargv) - 3):
-                goal.ignore_object_list.append(myargv[i + 3])
-        rospy.loginfo(
-            f'sending -> pick {object_to_pick} from {support_surface_name}'
-            ' <- goal to {pick_object_server_name} action server'
-        )
-        if len(goal.ignore_object_list) > 0:
-            rospy.logwarn(f'the following objects: {goal.ignore_object_list} will not be added to the planning scene')
+            goal.ignore_object_list = myargv[3:]
+
+        rospy.loginfo(f'Sending goal: pick {object_to_pick} from {support_surface_name} to {pick_object_server_name}')
+        if goal.ignore_object_list:
+            rospy.logwarn(f'The following objects will be ignored in planning: {goal.ignore_object_list}')
         else:
-            rospy.loginfo('all objects are taken into account in planning scene')
+            rospy.loginfo('All objects will be considered in the planning scene')
+
         action_client.send_goal(goal)
-        rospy.loginfo(f'waiting for result from {pick_object_server_name} action server')
+
+        # Wait for result with specified timeout
+        rospy.loginfo(f'Waiting for result from {pick_object_server_name} action server...')
         if action_client.wait_for_result(rospy.Duration.from_sec(timeout)):
             result = action_client.get_result()
-            rospy.loginfo(f'{pick_object_server_name} is done with execution, resuĺt was = "{result}"')
+            rospy.loginfo(f'{pick_object_server_name} completed execution with result = "{result}"')
             if result.success:
-                rospy.loginfo(f'Succesfully picked {object_to_pick}')
+                rospy.loginfo(f'Successfully picked {object_to_pick}')
             else:
                 rospy.logerr(f'Failed to pick {object_to_pick}')
         else:
-            rospy.logerr(f'Failed to pick {object_to_pick}, timeout?')
+            # Cancel the goal if timeout occurs
+            action_client.cancel_goal()
+            rospy.logerr(f'Failed to pick {object_to_pick} within the allocated time. Goal cancellation was sent.')
     else:
-        rospy.logerr(f'action server {pick_object_server_name} not available')
+        rospy.logerr(f'Action server {pick_object_server_name} not available within the timeout')

--- a/scripts/place_obj_test_action_client
+++ b/scripts/place_obj_test_action_client
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 import rospy
@@ -8,44 +8,53 @@ from grasplan.msg import PlaceObjectAction, PlaceObjectGoal
 
 if __name__ == '__main__':
     rospy.init_node('place_object_action_client')
+
+    # Check for namespace and arguments
     if len(sys.argv) > 1:
         if sys.argv[1] != '__ns:=mobipick':
-            rospy.logwarn('have you run this node without the mobipick as namespace? if so, it might not work!')
+            rospy.logwarn('Have you run this node without the "mobipick" namespace? It might not work!')
 
         myargv = rospy.myargv()
         if len(myargv) != 3:
             rospy.logfatal(f'Usage: {myargv[0]} support_surface_name observe_before_placing')
             sys.exit(1)
+
+        # Parse arguments
         support_surface_name = myargv[1]
-        if myargv[2] == 'true' or myargv[2] == 'True':
-            observe_before_place = True
-        elif myargv[2] == 'false' or myargv[2] == 'False':
-            observe_before_place = False
+        observe_before_place = myargv[2].lower() == 'true'
     else:
-        rospy.logwarn(
-            'you have run this node without arguments, at least the mobiplace namespace is expected!'
-            ' ( __ns:=mobiplace )'
-        )
-    timeout = 50.0  # in seconds, default: 50.0
+        rospy.logwarn('Node launched without arguments; expected at least the "mobipick" namespace ( __ns:=mobipick ).')
+        sys.exit(1)
+
+    # Action client setup
+    timeout = 50.0  # Timeout in seconds for waiting for result
     place_object_server_name = 'place_object'
     action_client = actionlib.SimpleActionClient(place_object_server_name, PlaceObjectAction)
-    rospy.loginfo(f'waiting for {place_object_server_name} action server')
+
+    # Wait for the action server to be available
+    rospy.loginfo(f'Waiting for {place_object_server_name} action server...')
     if action_client.wait_for_server(timeout=rospy.Duration.from_sec(10.0)):
-        rospy.loginfo(f'found {place_object_server_name} action server')
+        rospy.loginfo(f'Connected to {place_object_server_name} action server')
+
+        # Send goal to action server
         goal = PlaceObjectGoal()
         goal.support_surface_name = support_surface_name
         goal.observe_before_place = observe_before_place
-        rospy.loginfo(f'sending place goal to {place_object_server_name} action server')
+        rospy.loginfo(f'Sending place goal to {place_object_server_name} action server')
         action_client.send_goal(goal)
-        rospy.loginfo(f'waiting for result from {place_object_server_name} action server')
+
+        # Wait for result with specified timeout
+        rospy.loginfo(f'Waiting for result from {place_object_server_name} action server...')
         if action_client.wait_for_result(rospy.Duration.from_sec(timeout)):
             result = action_client.get_result()
-            rospy.loginfo(f'{place_object_server_name} is done with execution, resuĺt was = "{result}"')
+            rospy.loginfo(f'{place_object_server_name} completed execution with result = "{result}"')
             if result.success:
-                rospy.loginfo('Succesfully placed object')
+                rospy.loginfo('Successfully placed object')
             else:
                 rospy.logerr('Failed to place object')
         else:
-            rospy.logerr('Failed to place object, timeout?')
+            # Cancel the goal if timeout occurs
+            action_client.cancel_goal()
+            rospy.logerr('Failed to place object within the allocated time. Goal cancellation was sent.')
     else:
-        rospy.logerr(f'action server {place_object_server_name} not available')
+        rospy.logerr(f'Action server {place_object_server_name} not available within the timeout')

--- a/src/grasplan/insert.py
+++ b/src/grasplan/insert.py
@@ -37,6 +37,7 @@ from std_srvs.srv import Empty
 from pose_selector.srv import ClassQuery
 from grasplan.tools.common import objectToPick  # name is misleading, in this case we want to insert an object in it
 from grasplan.msg import InsertObjectAction, InsertObjectResult
+from grasplan.tools.action_client_helper import ActionClientHelper
 
 
 class InsertTools:
@@ -63,6 +64,12 @@ class InsertTools:
         self.insert_action_server = actionlib.SimpleActionServer(
             'insert_object', InsertObjectAction, self.insert_obj_action_callback, False
         )
+        # prepare fallback option because moveit pickup action server ignores preemption requests
+        # create joint controller cancellers for both arm and gripper
+        ns = rospy.get_namespace().strip('/')  # programatically get robot namespace
+        self.action_client_helper = ActionClientHelper(
+            ns, self.insert_action_server, controller_names=['arm', 'gripper']
+        )
         self.insert_action_server.start()
 
         # give some time for publishers and Subscribers to register
@@ -71,6 +78,8 @@ class InsertTools:
     def insert_obj_action_callback(self, goal):
         success = False
         for i in range(2):  # 0, 1 = 2 attemps
+            if self.insert_action_server.is_preempt_requested():
+                break
             rospy.loginfo(f'Insert object: attempt number {i + 1}')
             if i == 0:  # first try, optimistic, keep same orientation as support object
                 # disentangle cable only on first attempt
@@ -98,6 +107,9 @@ class InsertTools:
                 break
         if success:
             self.insert_action_server.set_succeeded(InsertObjectResult(success=True))
+        elif self.insert_action_server.is_preempt_requested():
+            rospy.logwarn("Preemption requested during insert goal processing.")
+            self.insert_action_server.set_preempted()
         else:
             self.insert_action_server.set_aborted(InsertObjectResult(success=False))
 
@@ -142,6 +154,8 @@ class InsertTools:
         assert isinstance(observe_before_insert, bool)
         assert isinstance(support_object_name_as_string, str)
 
+        INSERT_OBJECT_SERVER_NAME = 'place'  # we use the same action server as in place object
+
         support_object = objectToPick(support_object_name_as_string)
 
         if len(self.place.scene.get_attached_objects().keys()) == 0:
@@ -179,8 +193,8 @@ class InsertTools:
                     rospy.loginfo(f'going to intermediate arm pose {arm_pose} to disentangle cable')
                     self.place.move_arm_to_posture(arm_pose)
 
-        action_client = actionlib.SimpleActionClient(self.place.place_object_server_name, PlaceAction)
-        rospy.loginfo(f'sending insert command as a place goal to {self.place.place_object_server_name} action server')
+        action_client = actionlib.SimpleActionClient(INSERT_OBJECT_SERVER_NAME, PlaceAction)
+        rospy.loginfo(f'sending insert command as a place goal to {INSERT_OBJECT_SERVER_NAME} action server')
 
         # get object position [x, y] -> without orientation for now
         support_object_pose = self.get_support_object_pose(support_object)
@@ -201,8 +215,11 @@ class InsertTools:
         rospy.loginfo('clearing octomap')
         rospy.ServiceProxy('clear_octomap', Empty)()
 
+        if self.insert_action_server.is_preempt_requested():
+            return False
+
         if action_client.wait_for_server(timeout=rospy.Duration.from_sec(2.0)):
-            rospy.loginfo(f'found {self.place.place_object_server_name} action server')
+            rospy.loginfo(f'found {INSERT_OBJECT_SERVER_NAME} action server')
             goal = self.place.make_place_goal_msg(
                 object_to_be_inserted,
                 support_object.get_object_class_and_id_as_string(),
@@ -210,12 +227,12 @@ class InsertTools:
                 use_path_constraints=False,
             )
 
-            rospy.loginfo(
-                f'sending place {object_to_be_inserted} goal to {self.place.place_object_server_name} action server'
-            )
-            action_client.send_goal(goal)
-            rospy.loginfo(f'waiting for result from {self.place.place_object_server_name} action server')
-            if action_client.wait_for_result(rospy.Duration.from_sec(self.place.timeout)):
+            rospy.loginfo(f'sending place {object_to_be_inserted} goal to {INSERT_OBJECT_SERVER_NAME} action server')
+            rospy.loginfo(f'waiting for result from {INSERT_OBJECT_SERVER_NAME} action server')
+            if self.action_client_helper.send_goal_to_rogue_server_and_wait(goal, action_client, patience_timeout=0.1):
+                if self.insert_action_server.is_preempt_requested():
+                    return False
+
                 result = action_client.get_result()
 
                 # handle moveit pick result
@@ -233,7 +250,7 @@ class InsertTools:
                     print_moveit_error(result.error_code.val)
                 return False
         else:
-            rospy.logerr(f'action server {self.place.place_object_server_name} not available (we use it for insertion)')
+            rospy.logerr(f'action server {INSERT_OBJECT_SERVER_NAME} not available (we use it for insertion)')
             return False
         return False
 

--- a/src/grasplan/insert.py
+++ b/src/grasplan/insert.py
@@ -135,7 +135,7 @@ class InsertTools:
                 return pose  # of type object_pose_msgs/ObjectPose.msg
         rospy.logerr(
             f'At least one object of the class {support_object.obj_class} was perceived but is not the one you want,'
-            ' with id: {support_object.id}'
+            f' with id: {support_object.id}'
         )
         return None
 

--- a/src/grasplan/pick.py
+++ b/src/grasplan/pick.py
@@ -143,12 +143,11 @@ class PickTools:
         self.pick_action_server = actionlib.SimpleActionServer(
             'pick_object', PickObjectAction, self.pick_obj_action_callback, False
         )
-        self.pick_action_server.start()
-
         # prepare fallback option because moveit pickup action server ignores preemption requests
         # create joint controller cancellers for both arm and gripper
         ns = rospy.get_namespace().strip('/')  # programatically get robot namespace
         self.action_client_helper = ActionClientHelper(ns, self.pick_action_server, controller_names=['arm', 'gripper'])
+        self.pick_action_server.start()
 
         rospy.loginfo('pick node ready!')
 

--- a/src/grasplan/pick.py
+++ b/src/grasplan/pick.py
@@ -90,8 +90,8 @@ class PickTools:
         pose_selector_delete_srv_name = rospy.get_param('~pose_selector_delete_srv_name', '/pose_selector_delete')
         rospy.loginfo(
             f'waiting for pose selector services: {pose_selector_activate_srv_name},'
-            ' {pose_selector_class_query_srv_name}, {pose_selector_get_all_poses_srv_name},'
-            ' {pose_selector_delete_srv_name}'
+            f' {pose_selector_class_query_srv_name}, {pose_selector_get_all_poses_srv_name},'
+            f' {pose_selector_delete_srv_name}'
         )
         # if wait_for_service fails, it will throw a
         # rospy.exceptions.ROSException, and the node will exit (as long as
@@ -248,7 +248,7 @@ class PickTools:
         if not object_found:
             rospy.logerr(
                 'the specific object you want to pick was not found:'
-                ' {object_to_pick.get_object_class_and_id_as_string()}'
+                f' {object_to_pick.get_object_class_and_id_as_string()}'
             )
             return None, None, None
         return (

--- a/src/grasplan/tools/action_client_helper.py
+++ b/src/grasplan/tools/action_client_helper.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2024 DFKI GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import rospy
+
+# action client helper
+import actionlib
+from actionlib_msgs.msg import GoalStatus
+
+# trajectory canceller
+from control_msgs.msg import FollowJointTrajectoryActionGoal
+from actionlib_msgs.msg import GoalID, GoalStatusArray
+import re  # regular expressions
+
+
+class TrajectoryCanceller:
+    """
+    Helper class that:
+    1) keeps track of goals, adds them to a set and removes them if completed.
+    2) offers a cancel_all_goals method that iterates over unfinished tracked goals and sends cancellations
+    via topic to each of them.
+
+    Motivation for this helper class:
+    Sometimes rogue action servers ignore cancellation requests.
+    As a workaround once can send such cancellation requests directly to the joint trajectory controller,
+    effectively crippling the ability to actuate the arm or the gripper.
+    """
+
+    def __init__(self, base_topic):
+        """
+        base_topic example: '/namespace/arm_controller/follow_joint_trajectory/'
+        '_controller' str should be there, because is used to compute the canceller_type
+        which is used for logging purposes...
+        """
+        # programatically get the name of the canceller
+        match = re.search(r'/(\w+)_controller', base_topic)
+        self.canceller_type = match.group(1) if match else 'unknown'
+
+        goal_topic = base_topic + 'goal'
+        cancel_topic = base_topic + 'cancel'
+        status_topic = base_topic + 'status'
+
+        self.cancel_pub = rospy.Publisher(cancel_topic, GoalID, queue_size=1)
+        self.goal_set = set()  # Set to hold unique goal_ids
+
+        rospy.Subscriber(goal_topic, FollowJointTrajectoryActionGoal, self.goal_callback)
+        rospy.Subscriber(status_topic, GoalStatusArray, self.status_callback)
+        rospy.loginfo(
+            f"TrajectoryCanceller initialized for goal topic '{goal_topic}', "
+            f"cancel topic '{cancel_topic}', and status topic '{status_topic}'"
+        )
+
+    def goal_callback(self, msg):
+        # Add the new goal_id to the set if it's not already present
+        goal_id = msg.goal_id.id
+        if goal_id not in self.goal_set:
+            self.goal_set.add(goal_id)
+            rospy.loginfo(f'Captured new goal_id for {self.canceller_type}: {goal_id}')
+
+    def status_callback(self, msg):
+        # Iterate over each status in the status_list
+        for status in msg.status_list:
+            goal_id = status.goal_id.id
+            goal_status = status.status
+            # If the status is SUCCEEDED, remove it from the set
+            if goal_status == GoalStatus.SUCCEEDED:
+                if goal_id in self.goal_set:
+                    self.goal_set.remove(goal_id)
+                    rospy.loginfo(f'Goal {goal_id} succeeded and removed from set ({self.canceller_type})')
+
+    def has_active_goals(self):
+        # Check if there are any goals in the set
+        return len(self.goal_set) > 0
+
+    def cancel_all_goals(self):
+        if self.has_active_goals():
+            # Iterate over all goal_ids in the set, sending a cancel request for each
+            while self.goal_set:
+                goal_id = self.goal_set.pop()  # Remove any goal_id from the set
+                cancel_msg = GoalID()
+                cancel_msg.id = goal_id
+                self.cancel_pub.publish(cancel_msg)
+                rospy.loginfo(f'Sent {self.canceller_type} cancel request for goal_id: {goal_id}')
+            return True
+        else:
+            rospy.logwarn(f'No active goals to cancel for {self.canceller_type}')
+            return False
+
+
+class ActionClientHelper:
+    """
+    A customized alternative to action_client.wait_for_result(...)
+    that includes support for bypassing unresponsive action servers (e.g., MoveIt pickup server).
+    If the server ignores preemption requests, this method forcibly cancels goals
+    by directly interacting with the joint trajectory controllers.
+    """
+
+    def __init__(self, ns, action_server, controller_names):
+        """
+        Initializes the action server helper.
+
+        :param ns: The namespace under which the action server and controllers are operating.
+        :param type: A string indicating the type of action server, e.g., 'pick', 'place', or 'insert'.
+        :param action_server: An instance of the actionlib server that manages the corresponding actions.
+        :param controller_names: A list of controller names, e.g., ['arm', 'gripper'],
+                                used to create trajectory cancellers for each controller.
+
+        Example:
+            If `ns` is '/robot_namespace' and `controller_names` is ['arm', 'gripper'],
+            the trajectory canceller topics will be:
+                - /robot_namespace/arm_controller/follow_joint_trajectory/cancel
+                - /robot_namespace/gripper_controller/follow_joint_trajectory/cancel
+        """
+        self.canceller_list = []
+        for controller_name in controller_names:
+            self.canceller_list.append(
+                TrajectoryCanceller(f'/{ns}/{controller_name}_controller/follow_joint_trajectory/')
+            )
+
+        self.action_server = action_server
+
+    def send_goal_to_rogue_server_and_wait(self, goal, action_client, patience_timeout=0.1):
+        """
+        Executes an action with support for forced preemption when the action server is unresponsive.
+
+        :param goal: The goal to send to the action server.
+        :param action_client: The SimpleActionClient connected to the rogue server.
+        :param patience_timeout: Duration to wait for the action server to acknowledge
+                                 preemption before forcing goal cancellation.
+        :returns: True if the action completes successfully, False otherwise.
+        """
+        # Send the goal to the action server
+        action_client.send_goal(goal)
+
+        loop_period = rospy.Duration(0.1)  # Wake up every 0.1 seconds to check preemption
+
+        with action_client.done_condition:
+            while not rospy.is_shutdown():
+                # Wait with a timeout to periodically check preemption
+                action_client.done_condition.wait(loop_period.to_sec())
+
+                # Check if the goal has been completed
+                if action_client.simple_state == actionlib.SimpleGoalState.DONE:
+                    rospy.loginfo("Action completed successfully.")
+                    return True
+
+                # Check if user requested preemption
+                if self.action_server.is_preempt_requested():
+                    rospy.logwarn(
+                        f'grasplan {self.action_server.action_server.ns} ' 'action server goal cancel request received'
+                    )
+                    action_client.cancel_goal()
+                    break
+
+        # Handle post-loop actions (preemption acknowledgment)
+        if action_client.simple_state != actionlib.SimpleGoalState.DONE:
+            rospy.loginfo(f"Waiting for {patience_timeout} seconds for MoveIt action server acknowledgment...")
+            with action_client.done_condition:
+                action_client.done_condition.wait(rospy.Duration(patience_timeout).to_sec())
+
+            # If still not acknowledged, force preemption
+            if action_client.simple_state != actionlib.SimpleGoalState.DONE:
+                rospy.logwarn(
+                    "MoveIt action server did not acknowledged preemption within "
+                    f"{patience_timeout} s. Forcing preemption..."
+                )
+                self._force_preemption(action_client)
+                return False
+
+        rospy.logwarn("Action failed to complete successfully.")
+        return False
+
+    def _force_preemption(self, rogue_client, max_retries=100):
+        """
+        Repeatedly sends cancellation requests directly to joint trajectory controllers
+        (bypassing MoveIt) until the rogue action server gives up and aborts.
+
+        :param rogue_client: The client connected to the rogue server.
+        :param max_retries: To guard against infinite loops
+        """
+        count = 1
+        while rogue_client.get_state() != GoalStatus.ABORTED:
+            rospy.loginfo(f'Force canceling joint trajectory goals at 10 Hz until aborted, attempt {count}')
+            for canceller in self.canceller_list:
+                if canceller.has_active_goals():
+                    canceller.cancel_all_goals()
+            rospy.sleep(0.1)  # Short wait before retrying
+            count += 1
+
+            if count > max_retries:
+                rospy.logerr("Exceeded maximum retries for forcing preemption.")
+                break

--- a/src/grasplan/tools/action_client_helper.py
+++ b/src/grasplan/tools/action_client_helper.py
@@ -72,7 +72,7 @@ class TrajectoryCanceller:
         goal_id = msg.goal_id.id
         if goal_id not in self.goal_set:
             self.goal_set.add(goal_id)
-            rospy.loginfo(f'Captured new goal_id for {self.canceller_type}: {goal_id}')
+            rospy.logdebug(f'Captured new goal_id for {self.canceller_type}: {goal_id}')
 
     def status_callback(self, msg):
         # Iterate over each status in the status_list
@@ -83,7 +83,7 @@ class TrajectoryCanceller:
             if goal_status == GoalStatus.SUCCEEDED:
                 if goal_id in self.goal_set:
                     self.goal_set.remove(goal_id)
-                    rospy.loginfo(f'Goal {goal_id} succeeded and removed from set ({self.canceller_type})')
+                    rospy.logdebug(f'Goal {goal_id} succeeded and removed from set ({self.canceller_type})')
 
     def has_active_goals(self):
         # Check if there are any goals in the set

--- a/src/grasplan/tools/support_plane_tools.py
+++ b/src/grasplan/tools/support_plane_tools.py
@@ -153,6 +153,7 @@ def well_separated(x_y_list, candidate_x, candidate_y, min_dist=0.2):
 
 
 def gen_place_poses_from_plane(
+    place_action_server,
     object_class: str,
     support_object: str,
     plane: List[str],
@@ -179,6 +180,9 @@ def gen_place_poses_from_plane(
         object_pose_msg.class_id = object_class
         count = 0
         while 1:
+            if place_action_server.is_preempt_requested():
+                rospy.logwarn('Preemption requested. Abort place poses generation.')
+                return object_list_msg
             candidate_x = round(random.uniform(plane[0].x, plane[1].x), 4)
             candidate_y = round(random.uniform(plane[0].y, plane[3].y), 4)
             if support_object in ignore_min_dist_list:


### PR DESCRIPTION
## Brief

This PR updates Grasplan to listen to preemption requests from the user and act accordingly. Specifically, preemption requests are now forwarded to MoveIt.

NOTE: Not (yet) tested on real robot.

## Issue Encountered:

While MoveIt implements a preemption callback in its pick_place_action_capability.cpp (reference: https://github.com/moveit/moveit/blob/noetic-devel/moveit_ros/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp#L405), the callback is currently empty, resulting in MoveIt ignoring preemption requests. This behavior prevents MoveIt from halting ongoing actions when preempted by the user.

## Workaround Implemented:

To address this limitation, we introduced a custom canceller that directly hijacks the arm and gripper controllers. The custom canceller achieves the following:

- Tracks Incoming Goals: It monitors all controller goals sent by MoveIt to the arm and gripper controllers.
- Sends Preemption Requests: For each tracked goal, the canceller issues a preemption request to the controllers. This effectively halts the arm and prevents further movement.

## Conclusion

This approach ensures that preemption requests are honored, even when MoveIt itself fails to handle them properly.